### PR TITLE
Respect defaults in photoprism.in

### DIFF
--- a/files/photoprism.in
+++ b/files/photoprism.in
@@ -19,12 +19,16 @@ load_rc_config $name
 
 : ${photoprism_enable="NO"}
 
-export PHOTOPRISM_AUTH_MODE=${photoprism_auth_mode}
+if [ "$photoprism_auth_mode" ]; then photoprism_args="${photoprism_args} --auth-mode=${photoprism_auth_mode}"; fi
+if [ "$photoprism_defaultsyaml" ]; then photoprism_args="${photoprism_args} --defaults-yaml=${photoprism_defaultsyaml}"; fi
+if [ "$photoprism_assetspath" ]; then photoprism_args="${photoprism_args} --assets-path=${photoprism_assetspath}"; fi
+if [ "$photoprism_storagepath" ]; then 
+  photoprism_args="${photoprism_args} --storage-path=${photoprism_storagepath} --originals-path=${photoprism_storagepath}/originals --import-path=${photoprism_storagepath}/import"
+fi
 
 pidfile="/var/run/photoprism.pid"
 procname="/usr/local/bin/photoprism"
 command="/usr/sbin/daemon"
-command_args="-f -T photoprism -p ${pidfile} -u photoprism /usr/local/bin/photoprism --defaults-yaml=${photoprism_defaultsyaml} --assets-path=${photoprism_assetspath} --storage-path=${photoprism_storagepath} --originals-path=${photoprism_storagepath}/originals --import-path=${photoprism_storagepath}/import ${photoprism_args} start"
+command_args="-f -T photoprism -p ${pidfile} -u photoprism /usr/local/bin/photoprism ${photoprism_args} start"
 
 run_rc_command "$1"
-


### PR DESCRIPTION
I'm a lazy person that would like to use `/usr/local/bin/photoprism` from the command line without having to pass in all the args and paths already configured in `/etc/rc.conf`, so I was glad to find that I could put all the configuration in `/etc/photoprism/defaults.yml`:
https://docs.photoprism.app/getting-started/config-files/defaults/

That works for calling `/usr/local/bin/photoprism`, but doesn't work for the rc.d script. Even though the port installation says it should, if I set `photoprism_defaultsyaml`:
https://github.com/huo-ju/photoprism-freebsd-port/blob/main/files/pkg-message.in#L9-L11

The problem is that, although a defaults YAML file can be specified, the rc script actually overwrites some configurations to empty. Ex: `--assets-path=${photoprism_assetspath}` expands to `--assets-path= ` and sets the path to empty, even if it is specified in your YAML configuration file (but not in `/etc/rc.conf`).

I could duplicate configurations between `/etc/rc.conf` and `/etc/photoprism/defaults.yml`, but I'd prefer to have the RC script always respect the defaults.

With the changes from this PR, one could create a `/etc/photoprism/defaults.yml` file with all the configuration they need and call `/usr/local/bin/photoprism` from the command line and have the rc script read the file and apply its settings with only `photoprism_enable="YES"` in their `/etc/rc.conf`.

I'm no SH/BASH wizard, I have tested my changes, but I suspect they could be simplified to something more idiomatic.