### PR TITLE
The auto-update/build workflows

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -3,18 +3,43 @@ name: Update Latest
 on:
   workflow_dispatch:
 
-
 jobs:
   UpdateToLatest:
+    name: Update to Latest
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - id: getRelease
+        name: Fetch latest release
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: photoprism/photoprism
-      - run: |
-          VERSION=`echo "${{ steps.getRelease.outputs.release }}"|cut -d "-" -f 1``
-          sed -i "s/DISTVERSION=.*/DISTVERSION=g${VERSION}/g" Makefile
-          sed -i "s/GH_TAGNAME=.*/GH_TAGNAME=${{ steps.getRelease.outputs.release }}/g" Makefile
-          cat Makefile
+      - name: Update Makefile
+        run: |
+          export VERSION=`echo "${{ steps.getRelease.outputs.release }}"|cut -d "-" -f 1`
+          sed -i "s/DISTVERSION=.*/DISTVERSION=	g20${VERSION}/g" Makefile
+          sed -i "s/GH_TAGNAME=.*/GH_TAGNAME=	${{ steps.getRelease.outputs.release }}/g" Makefile
+      - name: Build The Latest
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install -y gmake npm wget pkgconf git go122 portsnap ffmpeg p5-Image-ExifTool libheif vips bsddialog portconfig
+            mkdir -p /var/db/portsnap && portsnap --interactive auto > /dev/null
+            fetch https://github.com/lapo-luchini/libtensorflow1-freebsd-port/releases/download/v1.15.5_2/libtensorflow1-1.15.5_2.pkg-FreeBSD-14.0-amd64-AVX-SSE42.pkg -o /tmp/libtf.pkg
+            pkg add /tmp/libtf.pkg
+          run: |
+            git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
+            make makesum
+            make -j $(nproc)
+            make makeplist >pkg-plist
+            tail -n +2 pkg-plist >pkg-plist.tmp
+            mv pkg-plist.tmp pkg-plist
+      - name: Show diff
+        run: git diff
+      - name: Commit and push
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "[Auto update] Update to ${{ steps.getRelease.outputs.release }}"

--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -43,3 +43,9 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "[Auto update] Update to ${{ steps.getRelease.outputs.release }}"
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: Photoprism ${{ steps.getRelease.outputs.release }} packages for FreeBSD
+          tag_name: ${{ steps.getRelease.outputs.release }}
+          name: ${{ steps.getRelease.outputs.release }}

--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -1,0 +1,16 @@
+name: Update Latest
+
+on:
+  workflow_dispatch:
+
+
+jobs:
+  UpdateToLatest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: getRelease
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: photoprism/photoprism
+      - run: echo "Latest release is ${{ steps.getRelease.outputs.release }}"

--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -13,4 +13,8 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           repository: photoprism/photoprism
-      - run: echo "Latest release is ${{ steps.getRelease.outputs.release }}"
+      - run: |
+          VERSION=`echo "${{ steps.getRelease.outputs.release }}"|cut -d "-" -f 1``
+          sed -i "s/DISTVERSION=.*/DISTVERSION=g${VERSION}/g" Makefile
+          sed -i "s/GH_TAGNAME=.*/GH_TAGNAME=${{ steps.getRelease.outputs.release }}/g" Makefile
+          cat Makefile

--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -1,0 +1,54 @@
+name: Create Binary Pkg
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_14:
+    name: Build for FreeBSD 14
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build PKG
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install -y gmake npm wget pkgconf git go122 portsnap ffmpeg p5-Image-ExifTool libheif vips bsddialog portconfig
+            mkdir -p /var/db/portsnap && portsnap --interactive auto > /dev/null
+            fetch https://github.com/lapo-luchini/libtensorflow1-freebsd-port/releases/download/v1.15.5_2/libtensorflow1-1.15.5_2.pkg-FreeBSD-14.0-amd64-AVX-SSE42.pkg -o /tmp/libtf.pkg
+            pkg add /tmp/libtf.pkg
+          run: |
+            git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
+            make package
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: freebsd-14
+          path: |
+            work/pkg/*.pkg
+  build_13:
+    name: Build for FreeBSD 13
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build PKG
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install -y gmake npm wget pkgconf git go122 ffmpeg p5-Image-ExifTool libheif vips bsddialog portconfig
+            mkdir -p /var/db/portsnap && portsnap --interactive auto > /dev/null
+            fetch https://github.com/lapo-luchini/libtensorflow1-freebsd-port/releases/download/v1.15.5_2/libtensorflow1-1.15.5_2.pkg-FreeBSD-13.2-amd64-AVX-SSE42.pkg -o /tmp/libtf.pkg
+            pkg add /tmp/libtf.pkg
+          run: |
+            git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
+            make package
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: freebsd-13
+          path: |
+            work/pkg/*.pkg

--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Build PKG
         uses: vmactions/freebsd-vm@v1
         with:
-          usesh: true
           prepare: |
             pkg install -y gmake npm wget pkgconf git go122 portsnap ffmpeg p5-Image-ExifTool libheif vips bsddialog portconfig
             mkdir -p /var/db/portsnap && portsnap --interactive auto > /dev/null
@@ -21,7 +20,7 @@ jobs:
           run: |
             git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
             make package
-            bash -c "for file in work/pkg/*.pkg;do mv $file ${file//\.pkg/-FreeBSD-$(uname -r).pkg}; done"
+            python3 -c "import glob, os; [os.rename(f, f.replace('.pkg', '-FreeBSD-' + os.uname().release + '.pkg')) for f in glob.glob('work/pkg/*.pkg')]"
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -36,7 +35,6 @@ jobs:
       - name: Build PKG
         uses: vmactions/freebsd-vm@v1
         with:
-          usesh: true
           release: "13.3"
           prepare: |
             pkg install -y gmake npm wget pkgconf git go122 ffmpeg p5-Image-ExifTool libheif vips bsddialog portconfig
@@ -46,7 +44,7 @@ jobs:
           run: |
             git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
             make package
-            bash -c "for file in work/pkg/*.pkg;do mv $file ${file//\.pkg/-FreeBSD-$(uname -r).pkg}; done"
+            python3 -c "import glob, os; [os.rename(f, f.replace('.pkg', '-FreeBSD-' + os.uname().release + '.pkg')) for f in glob.glob('work/pkg/*.pkg')]"
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -20,7 +20,7 @@ jobs:
           run: |
             git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
             make package
-            python3 -c "import glob, os; [os.rename(f, f.replace('.pkg', '-FreeBSD-' + os.uname().release + '.pkg')) for f in glob.glob('work/pkg/*.pkg')]"
+            python3.11 -c "import glob, os; [os.rename(f, f.replace('.pkg', '-FreeBSD-' + os.uname().release + '.pkg')) for f in glob.glob('work/pkg/*.pkg')]"
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -44,7 +44,7 @@ jobs:
           run: |
             git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
             make package
-            python3 -c "import glob, os; [os.rename(f, f.replace('.pkg', '-FreeBSD-' + os.uname().release + '.pkg')) for f in glob.glob('work/pkg/*.pkg')]"
+            python3.11 -c "import glob, os; [os.rename(f, f.replace('.pkg', '-FreeBSD-' + os.uname().release + '.pkg')) for f in glob.glob('work/pkg/*.pkg')]"
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -1,9 +1,7 @@
 name: Create Binary Pkg
 
 on:
-  push:
-    branches:
-      - main
+  workflow_call:
 
 jobs:
   build_14:
@@ -23,6 +21,7 @@ jobs:
           run: |
             git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
             make package
+            for file in work/pkg/*.pkg;do mv $file ${file//\.pkg/-FreeBSD-$(uname -r).pkg}; done
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -47,6 +46,7 @@ jobs:
           run: |
             git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
             make package
+            for file in work/pkg/*.pkg;do mv $file ${file//\.pkg/-FreeBSD-$(uname -r).pkg}; done
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -21,7 +21,7 @@ jobs:
           run: |
             git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
             make package
-            for file in work/pkg/*.pkg;do mv $file ${file//\.pkg/-FreeBSD-$(uname -r).pkg}; done
+            bash -c "for file in work/pkg/*.pkg;do mv $file ${file//\.pkg/-FreeBSD-$(uname -r).pkg}; done"
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -46,7 +46,7 @@ jobs:
           run: |
             git config --global --add safe.directory /home/runner/work/photoprism-freebsd-port/photoprism-freebsd-port
             make package
-            for file in work/pkg/*.pkg;do mv $file ${file//\.pkg/-FreeBSD-$(uname -r).pkg}; done
+            bash -c "for file in work/pkg/*.pkg;do mv $file ${file//\.pkg/-FreeBSD-$(uname -r).pkg}; done"
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -38,6 +38,7 @@ jobs:
         uses: vmactions/freebsd-vm@v1
         with:
           usesh: true
+          release: "13.3"
           prepare: |
             pkg install -y gmake npm wget pkgconf git go122 ffmpeg p5-Image-ExifTool libheif vips bsddialog portconfig
             mkdir -p /var/db/portsnap && portsnap --interactive auto > /dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+
+jobs:
+  Build_Packages:
+    secrets: inherit
+    permissions:
+      contents: write
+      checks: write
+      actions: read
+      issues: read
+      packages: write
+      pull-requests: read
+      repository-projects: read
+      statuses: read
+    uses: ./.github/workflows/build_pkg.yml
+  Upload_Artifacts:
+    needs: Build_Packages
+    permissions:
+      contents: write
+      checks: write
+      actions: read
+      issues: read
+      packages: write
+      pull-requests: read
+      repository-projects: read
+      statuses: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: freebsd-14
+          path: target/
+      - uses: actions/download-artifact@v4
+        with:
+          name: freebsd-13
+          path: target/
+      - uses: alexellis/upload-assets@0.4.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          asset_paths: '[ "target/*.pkg" ]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   Build_Packages:
+    name: Build Packages
     secrets: inherit
     permissions:
       contents: write
@@ -21,6 +22,7 @@ jobs:
       statuses: read
     uses: ./.github/workflows/build_pkg.yml
   Upload_Artifacts:
+    name: Upload to release artifacts
     needs: Build_Packages
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
   release:
     types:
       - published
+  workflow_run:
+    workflows: ["Update Latest"]
+    types: [completed]
 
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ EXTRACT_DEPENDS=  ${RUN_DEPENDS} \
 
 BUILD_DEPENDS= ${EXTRACT_DEPENDS} 
 
-USES= gmake go:1.21,modules python:3.6+,build
+USES= gmake go:1.22,modules python:3.6+,build
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	photoprism

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	photoprism
-DISTVERSION=	g20240711
+DISTVERSION=	g20240915
 CATEGORIES=	www
 
 MAINTAINER=	huoju@devep.net
@@ -31,7 +31,7 @@ USES= gmake go:1.22,modules python:3.6+,build
 USE_GITHUB=	yes
 GH_ACCOUNT=	photoprism
 GH_PROJECT=	photoprism
-GH_TAGNAME=     240711-2197af848
+GH_TAGNAME=	240915-e1280b2fb
 
 USE_RC_SUBR=    photoprism
 PHOTOPRISM_DATA_DIR=      /var/db/photoprism

--- a/distinfo
+++ b/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1721639281
-SHA256 (photoprism-photoprism-g20240711-240711-2197af848_GH0.tar.gz) = 34b29308f64a50d2dbf482ccacbb7b5357e50f97e74a7ce0ee295c0a3bef695a
-SIZE (photoprism-photoprism-g20240711-240711-2197af848_GH0.tar.gz) = 64940285
+TIMESTAMP = 1727609221
+SHA256 (photoprism-photoprism-g20240915-240915-e1280b2fb_GH0.tar.gz) = 11dd12b493f18f44e052ef71b1f29b7b5a4237fc27df3e8afb23c08f2989e369
+SIZE (photoprism-photoprism-g20240915-240915-e1280b2fb_GH0.tar.gz) = 65012389

--- a/pkg-plist
+++ b/pkg-plist
@@ -1,4 +1,5 @@
 bin/photoprism
+etc/rc.d/photoprism
 /var/db/photoprism/assets/.buildignore
 /var/db/photoprism/assets/README
 /var/db/photoprism/assets/examples/.photoprism/example.jpg
@@ -112,6 +113,7 @@ bin/photoprism
 /var/db/photoprism/assets/locales/fa/default.po
 /var/db/photoprism/assets/locales/fi/default.po
 /var/db/photoprism/assets/locales/fr/default.po
+/var/db/photoprism/assets/locales/ga/default.po
 /var/db/photoprism/assets/locales/he/default.po
 /var/db/photoprism/assets/locales/hi/default.po
 /var/db/photoprism/assets/locales/hr/default.po
@@ -677,12 +679,12 @@ bin/photoprism
 /var/db/photoprism/assets/static/build/2d8017489da689caedc1.woff2
 /var/db/photoprism/assets/static/build/698bd8550d863c20a3e1.ttf
 /var/db/photoprism/assets/static/build/af9a28e7f261a412f581.eot
-/var/db/photoprism/assets/static/build/app.1727d6ad9ff7e01d3bf5.js
-/var/db/photoprism/assets/static/build/app.1727d6ad9ff7e01d3bf5.js.LICENSE.txt
-/var/db/photoprism/assets/static/build/app.fc3e74d7360094f1a4f9.css
+/var/db/photoprism/assets/static/build/app.405beb33c06fe9d84f44.css
+/var/db/photoprism/assets/static/build/app.7c8896e06308b4527cda.js
+/var/db/photoprism/assets/static/build/app.7c8896e06308b4527cda.js.LICENSE.txt
 /var/db/photoprism/assets/static/build/assets.json
 /var/db/photoprism/assets/static/build/f64c3af3d0d25b9e4e00.svg
-/var/db/photoprism/assets/static/build/share.9e32a8334b90c4bf11f3.js
+/var/db/photoprism/assets/static/build/share.73a026001890c81ab641.js
 /var/db/photoprism/assets/static/build/sw.js
 /var/db/photoprism/assets/static/font/Open Sans Bold/0-255.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/1024-1279.pbf
@@ -698,7 +700,7 @@ bin/photoprism
 /var/db/photoprism/assets/static/font/Open Sans Bold/12544-12799.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/1280-1535.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/12800-13055.pbf
-/var/db/photoprism/assets/static/font/Open Sans Bold/13056-13311.pbf
+/var/db/photoprism/assets/static/font/Open Sans Bold/13056-13%%PYTHON_SUFFIX%%.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/13312-13567.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/13568-13823.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/13824-14079.pbf
@@ -836,7 +838,7 @@ bin/photoprism
 /var/db/photoprism/assets/static/font/Open Sans Bold/44288-44543.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/44544-44799.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/44800-45055.pbf
-/var/db/photoprism/assets/static/font/Open Sans Bold/45056-45311.pbf
+/var/db/photoprism/assets/static/font/Open Sans Bold/45056-45%%PYTHON_SUFFIX%%.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/45312-45567.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/45568-45823.pbf
 /var/db/photoprism/assets/static/font/Open Sans Bold/45824-46079.pbf
@@ -954,7 +956,7 @@ bin/photoprism
 /var/db/photoprism/assets/static/font/Open Sans Italic/12544-12799.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/1280-1535.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/12800-13055.pbf
-/var/db/photoprism/assets/static/font/Open Sans Italic/13056-13311.pbf
+/var/db/photoprism/assets/static/font/Open Sans Italic/13056-13%%PYTHON_SUFFIX%%.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/13312-13567.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/13568-13823.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/13824-14079.pbf
@@ -1092,7 +1094,7 @@ bin/photoprism
 /var/db/photoprism/assets/static/font/Open Sans Italic/44288-44543.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/44544-44799.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/44800-45055.pbf
-/var/db/photoprism/assets/static/font/Open Sans Italic/45056-45311.pbf
+/var/db/photoprism/assets/static/font/Open Sans Italic/45056-45%%PYTHON_SUFFIX%%.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/45312-45567.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/45568-45823.pbf
 /var/db/photoprism/assets/static/font/Open Sans Italic/45824-46079.pbf
@@ -1210,7 +1212,7 @@ bin/photoprism
 /var/db/photoprism/assets/static/font/Open Sans Regular/12544-12799.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/1280-1535.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/12800-13055.pbf
-/var/db/photoprism/assets/static/font/Open Sans Regular/13056-13311.pbf
+/var/db/photoprism/assets/static/font/Open Sans Regular/13056-13%%PYTHON_SUFFIX%%.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/13312-13567.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/13568-13823.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/13824-14079.pbf
@@ -1348,7 +1350,7 @@ bin/photoprism
 /var/db/photoprism/assets/static/font/Open Sans Regular/44288-44543.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/44544-44799.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/44800-45055.pbf
-/var/db/photoprism/assets/static/font/Open Sans Regular/45056-45311.pbf
+/var/db/photoprism/assets/static/font/Open Sans Regular/45056-45%%PYTHON_SUFFIX%%.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/45312-45567.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/45568-45823.pbf
 /var/db/photoprism/assets/static/font/Open Sans Regular/45824-46079.pbf
@@ -1466,7 +1468,7 @@ bin/photoprism
 /var/db/photoprism/assets/static/font/Open Sans Semibold/12544-12799.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/1280-1535.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/12800-13055.pbf
-/var/db/photoprism/assets/static/font/Open Sans Semibold/13056-13311.pbf
+/var/db/photoprism/assets/static/font/Open Sans Semibold/13056-13%%PYTHON_SUFFIX%%.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/13312-13567.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/13568-13823.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/13824-14079.pbf
@@ -1604,7 +1606,7 @@ bin/photoprism
 /var/db/photoprism/assets/static/font/Open Sans Semibold/44288-44543.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/44544-44799.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/44800-45055.pbf
-/var/db/photoprism/assets/static/font/Open Sans Semibold/45056-45311.pbf
+/var/db/photoprism/assets/static/font/Open Sans Semibold/45056-45%%PYTHON_SUFFIX%%.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/45312-45567.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/45568-45823.pbf
 /var/db/photoprism/assets/static/font/Open Sans Semibold/45824-46079.pbf
@@ -1978,6 +1980,7 @@ bin/photoprism
 @dir /var/db/photoprism/assets/locales/fa
 @dir /var/db/photoprism/assets/locales/fi
 @dir /var/db/photoprism/assets/locales/fr
+@dir /var/db/photoprism/assets/locales/ga
 @dir /var/db/photoprism/assets/locales/he
 @dir /var/db/photoprism/assets/locales/hi
 @dir /var/db/photoprism/assets/locales/hr


### PR DESCRIPTION
Hello guys, I created a set of workflows which can do:
1. One-click update the `Makefile`,`pkg-plist` to the latest photoprism like 1810b5be3b66c1c26d48a16632141dcae85d3d66
2. Auto create a release, [example](https://github.com/Gaojianli/photoprism-freebsd-port/releases/tag/240915-e1280b2fb)
3. Compile a binary pkg for both FreeBSD 13 and 14 and then upload them to the release. 
![image](https://github.com/user-attachments/assets/ff7e82e0-0c22-403b-8671-7b5a7e2e1c50)

# How to use
Go to actions, and select `Update Latest`, click `run`

Also: I can't find a way to compile `libtensorflow1` in the action, so I finally use a binary from [here](https://github.com/lapo-luchini/libtensorflow1-freebsd-port/releases/tag/v1.15.5_2), thanks @lapo-luchini. 

Because this library is only used build and linked dynamically, so there is no security risk I think. But if you want to deploy photoprism on your computer, pick a suitable `libtensorflow1` is still necessary.

