### PR TITLE
fix upload artifacts

### DIFF
--- a/.github/workflows/auto_update.yml
+++ b/.github/workflows/auto_update.yml
@@ -43,9 +43,12 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "[Auto update] Update to ${{ steps.getRelease.outputs.release }}"
+      - name: Remote Extra Header
+        run: git config --unset http.https://github.com/.extraheader
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           body: Photoprism ${{ steps.getRelease.outputs.release }} packages for FreeBSD
           tag_name: ${{ steps.getRelease.outputs.release }}
           name: ${{ steps.getRelease.outputs.release }}
+          token: ${{ secrets.PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
   release:
     types:
       - published
-  workflow_run:
-    workflows: ["Update Latest"]
-    types: [completed]
 
 
 jobs:


### PR DESCRIPTION
The upload of the latest actions failed because this action is triggered by push instead of a release, so the action can't find a release to upload. This pr removes the incorrect trigger.


**After merged this, in order to create release, please set a personal token called `PAT` at repo [settings](https://github.com/huo-ju/photoprism-freebsd-port/settings/secrets/actions)**